### PR TITLE
fix(doc): typo in Node macro documentation

### DIFF
--- a/work/crates/derive/src/node/readme.md
+++ b/work/crates/derive/src/node/readme.md
@@ -430,7 +430,7 @@ enum MyNode {
 
   - ### Synchronization.
 
-    **Format:** `#[syncrhronization]`.
+    **Format:** `#[synchronization]`.
 
     Specifies a globally unique nested context for the error recovery
     synchronization.


### PR DESCRIPTION
In documentation for Node derive macro, attribute #[syncronization] was typo (/work/crates/derive/src/node/readme.md)

I agree to the terms of the [End User License Agreement](https://github.com/Eliah-Lakhin/lady-deirdre/blob/master/EULA.md).
I assign Eliah Lakhin (ru: Илья Александрович Лахин) all exclusive rights to the Derivative Work made by me