### PR TITLE
New Token macro operator for the case-insensitive grammars

### DIFF
--- a/work/crates/derive/src/lib.rs
+++ b/work/crates/derive/src/lib.rs
@@ -293,6 +293,9 @@ mod utils;
 ///    The inverted version of the previous operator that matches any character
 ///    outside of the specified set.
 ///
+///  - Case-insensitive matching: `i("foo")`.
+///    Matches "foo", "FOO", "Foo", and other case-insensitive variants.
+///
 ///  - Any Unicode uppercase character: `$upper`.
 ///
 ///  - Any Unicode lowercase character: `$lower`.

--- a/work/crates/derive/src/token/input.rs
+++ b/work/crates/derive/src/token/input.rs
@@ -205,8 +205,8 @@ impl TryFrom<DeriveInput> for TokenInput {
                         ));
                     }
 
-                    regex.transform(&TransformConfig::default());
                     regex.inline(&inline_map, &variant_map)?;
+                    regex.transform(&TransformConfig::default());
 
                     let _ = inline_map.insert(name, regex);
                 }
@@ -278,8 +278,8 @@ impl TryFrom<DeriveInput> for TokenInput {
 
             if let Some((_, rule)) = &mut variant.rule {
                 parsable += 1;
-                rule.transform(&TransformConfig::default());
                 rule.inline(&inline_map, &variant_map)?;
+                rule.transform(&TransformConfig::default());
                 alphabet.append(rule.alphabet());
             }
         }

--- a/work/crates/derive/src/token/input.rs
+++ b/work/crates/derive/src/token/input.rs
@@ -54,7 +54,7 @@ use crate::{
     token::{
         automata::{AutomataImpl, Scope, Terminal, TokenAutomata},
         opt::Opt,
-        regex::{Regex, RegexImpl},
+        regex::{Regex, RegexImpl, TransformConfig},
         variant::{TokenVariant, EOI, MISMATCH},
     },
     utils::{
@@ -205,6 +205,7 @@ impl TryFrom<DeriveInput> for TokenInput {
                         ));
                     }
 
+                    regex.transform(&TransformConfig::default());
                     regex.inline(&inline_map, &variant_map)?;
 
                     let _ = inline_map.insert(name, regex);
@@ -277,6 +278,7 @@ impl TryFrom<DeriveInput> for TokenInput {
 
             if let Some((_, rule)) = &mut variant.rule {
                 parsable += 1;
+                rule.transform(&TransformConfig::default());
                 rule.inline(&inline_map, &variant_map)?;
                 alphabet.append(rule.alphabet());
             }

--- a/work/crates/derive/src/token/regex.rs
+++ b/work/crates/derive/src/token/regex.rs
@@ -104,7 +104,7 @@ impl RegexImpl for Regex {
         match self {
             Self::Operand(Operand::Unresolved(_)) => system_panic!("Unresolved operand."),
 
-            Self::Operand(Operand::Dump(_, inner)) => inner.transform(config),
+            Self::Operand(Operand::Dump(_, inner)) => inner.transform(&TransformConfig::default()),
 
             Self::Operand(Operand::Transform(feature, inner)) => {
                 let mut inner = expect_some!(take(inner), "Empty transformation.",);


### PR DESCRIPTION
Fixes #18 

This Pull Request introduces a new Token macro operator `i("abc")` that matches surrounding expression in the case-insensitive way.