### PR TITLE
Enumeration iterators for the Repo collection

### DIFF
--- a/work/crates/main/src/arena/mod.rs
+++ b/work/crates/main/src/arena/mod.rs
@@ -40,5 +40,15 @@ pub(crate) use crate::arena::id::SubId;
 pub use crate::arena::{
     entry::{Entry, EntryIndex, EntryVersion, NIL_ENTRY},
     id::{Id, Identifiable},
-    repo::{Repo, RepoEntriesIntoIter, RepoEntriesIter, RepoIntoIter, RepoIter, RepoIterMut},
+    repo::{
+        Repo,
+        RepoEntriesIntoIter,
+        RepoEntriesIter,
+        RepoEnumIntoIter,
+        RepoEnumIter,
+        RepoEnumIterMut,
+        RepoIntoIter,
+        RepoIter,
+        RepoIterMut,
+    },
 };


### PR DESCRIPTION
Resolves #29 

Introduces three utility function to the `arena::Repo` collection:

1. `Repo::enumerate` - yields pairs of `(Entry, &T)` for non-exclusive iteration.
2. `Repo::enumerate_mut` - yields pairs of `(Entry, &mut T)` for exclusive iteration.
3. `Repo::into_enumeration` - yields owning pairs of `(Entry, T)`.
