### PR TITLE
Snippet improvements and fixes

### DIFF
--- a/work/crates/main/src/format/snippet.rs
+++ b/work/crates/main/src/format/snippet.rs
@@ -627,7 +627,7 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
                 .end(&mut is_first, self.formatter)?;
         }
 
-        let mut back_distance: usize = 0;
+        let mut back_distance = self.config.cover().min(usize::MAX / 2);
         let mut skip = false;
         let mut distances = Vec::with_capacity(lines.len());
 
@@ -640,7 +640,7 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
             distances.push(back_distance);
         }
 
-        back_distance = 0;
+        back_distance = self.config.cover().min(usize::MAX / 2);
 
         for (forward_distance, line) in distances.into_iter().rev().zip(lines) {
             if line.annotated || !self.config.show_numbers || !dim {
@@ -843,6 +843,8 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
                     .sort_by_key(|message| message.priority.order());
 
                 self.buffer.push(pending);
+
+                self.empty = true;
             }
 
             #[inline(always)]
@@ -933,7 +935,13 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
                 scanner.empty = false;
 
                 match ch {
-                    '\n' => scanner.submit(self.config),
+                    '\n' => {
+                        scanner.submit(self.config);
+
+                        if chunk.end() == self.code.length() {
+                            scanner.empty = false;
+                        }
+                    }
                     '\t' => scanner.pending.code.write_tab(self.config),
                     _ => scanner.pending.code.write_code_char(self.config, ch),
                 }

--- a/work/crates/main/src/format/snippet.rs
+++ b/work/crates/main/src/format/snippet.rs
@@ -65,33 +65,60 @@ use crate::{
 #[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
 #[non_exhaustive]
 pub struct SnippetConfig {
-    /// Whether the line numbers shall be shown on the left of the code content.
+    /// Enables line numbers on the left of the code content.
+    ///
+    /// Default: true.
     pub show_numbers: bool,
 
-    /// Whether the boxed frame shall surround the code content from all sides.
+    /// Renders boxed frame surrounding the code content.
+    ///
+    /// Default: true.
     pub draw_frame: bool,
 
-    /// If the code annotations are present in the snippet, whether
-    /// the non-annotated parts of the source code text shall be rendered
-    /// dimmed to focus the user on annotations.
+    /// If the snippet has annotation, non-annotated text will be dimmed to
+    /// focus user attention on the annotations.
+    ///
+    /// Default: true.
     pub dim_code: bool,
 
-    /// Whether the box drawing characters shall be rendered using ASCII
-    /// symbols only.
+    /// Using ASCII symbols only when rendering decoation elements.
+    ///
+    /// Default: false.
     pub ascii_drawing: bool,
 
-    /// Whether the CSI [styles](Style) shall be applied.
+    /// Enables [terminal escape codes](Style) when rendering the snippet.
     ///
-    /// When set to false, the renderer does not apply built-in styles
-    /// to annotations and other parts of the output, and the syntax
-    /// highlighter will disabled too.
+    /// By turning this flag off, the snippet will be rendered as "monochrome",
+    /// syntax highlighter will be forcefully disabled, annotations will not
+    /// receive any colors or terminal styles, and the user input (caption,
+    /// summary and the annotation message) will be sanitized from the terminal
+    /// escape codes too.
+    ///
+    /// Default: true.
     pub style: bool,
 
-    /// Whether the snippet caption (header) shall be rendered or disabled.
+    /// Allows caption (header) rendering.
+    ///
+    /// Default: true.
     pub caption: bool,
 
-    /// Whether the snippet summary (footer) shall be rendered or disabled.
+    /// Allows summery (footer) rendering.
+    ///
+    /// Default: true.
     pub summary: bool,
+
+    /// The minimal number of non-annotated lines surrounding annotated lines.
+    ///
+    /// Default: 2.
+    pub annotations_cover: usize,
+
+    /// The minimal outer width of the rendered content.
+    ///
+    /// Note that when the `draw_frame` is false, this value is practically
+    /// meaningless, because the snippet without a frame does not have a border.
+    ///
+    /// Default: 80.
+    pub width: usize,
 }
 
 impl Default for SnippetConfig {
@@ -113,6 +140,8 @@ impl SnippetConfig {
             style: true,
             caption: true,
             summary: true,
+            annotations_cover: 2,
+            width: 80,
         }
     }
 
@@ -130,22 +159,24 @@ impl SnippetConfig {
             style: false,
             caption: false,
             summary: false,
+            annotations_cover: 2,
+            width: 80,
         }
     }
 
     #[inline(always)]
     fn cover(&self) -> usize {
-        2
+        self.annotations_cover
     }
 
     #[inline(always)]
     fn continuation(&self) -> usize {
-        3
+        self.cover().checked_mul(2).unwrap_or(usize::MAX)
     }
 
     #[inline(always)]
     fn margin(&self) -> Length {
-        80
+        self.width
     }
 
     #[inline(always)]

--- a/work/crates/main/src/format/snippet.rs
+++ b/work/crates/main/src/format/snippet.rs
@@ -579,7 +579,7 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
         self
     }
 
-    /// Adds source code [span](ToSpan) that needs to be shown to the end user.
+    /// Adds source code [span](ToSpan) that needs to be included in the output.
     ///
     /// Inclusion fragments are similar to [annotations](Self::annotate), except
     /// that they don't receive special visual decorations in the final output,
@@ -589,10 +589,6 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
     /// annotations, the renderer only shows a part of the
     /// source code covering the lines of the specified spans, plus a few lines
     /// surrounding these spans.
-    ///
-    /// **Panic**
-    ///
-    /// Panics if the message has `\n` characters.
     pub fn include(&mut self, span: impl ToSpan) -> &mut Self {
         let span = match span.to_site_span(self.code) {
             Some(span) => span,

--- a/work/crates/main/src/format/snippet.rs
+++ b/work/crates/main/src/format/snippet.rs
@@ -75,8 +75,8 @@ pub struct SnippetConfig {
     /// Default: true.
     pub draw_frame: bool,
 
-    /// If the snippet has annotation, non-annotated text will be dimmed to
-    /// focus user attention on the annotations.
+    /// If the snippet has [annotations](Snippet::annotate), non-annotated
+    /// text will be dimmed to focus user attention on the annotated spans.
     ///
     /// Default: true.
     pub dim_code: bool,
@@ -97,20 +97,21 @@ pub struct SnippetConfig {
     /// Default: true.
     pub style: bool,
 
-    /// Allows caption (header) rendering.
+    /// Allows [caption](Snippet::set_caption) (header) rendering.
     ///
     /// Default: true.
     pub caption: bool,
 
-    /// Allows summary (footer) rendering.
+    /// Allows [summary](Snippet::set_summary) (footer) rendering.
     ///
     /// Default: true.
     pub summary: bool,
 
-    /// The minimal number of non-annotated lines surrounding annotated lines.
+    /// The minimal number of lines surrounding [annotated](Snippet::annotate)
+    /// lines and the lines with [inclusion](Snippet::include) spans.
     ///
     /// Default: 2.
-    pub annotations_cover: usize,
+    pub surround: usize,
 
     /// The minimal outer width of the rendered content.
     ///
@@ -140,7 +141,7 @@ impl SnippetConfig {
             style: true,
             caption: true,
             summary: true,
-            annotations_cover: 2,
+            surround: 2,
             width: 80,
         }
     }
@@ -159,14 +160,14 @@ impl SnippetConfig {
             style: false,
             caption: false,
             summary: false,
-            annotations_cover: 2,
+            surround: 2,
             width: 80,
         }
     }
 
     #[inline(always)]
     fn cover(&self) -> usize {
-        self.annotations_cover
+        self.surround
     }
 
     #[inline(always)]
@@ -520,9 +521,9 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
 
     /// Adds an annotation to the source code.
     ///
-    /// Annotations are the [spans](ToSpan) of source code that you want
-    /// to highlight for the end user, with or without a message,
-    /// such as syntax errors.
+    /// Annotations are the [spans](ToSpan) of source code that require end user
+    /// attention. For example, error messages connected with specific code
+    /// fragments.
     ///
     /// The `span` parameter specifies the annotation span.
     ///
@@ -533,9 +534,10 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
     /// but the message string must be one line (it should not contain
     /// `\n` chars).
     ///
-    /// When the snippet has annotations, the renderer will only show the source
-    /// code lines where the annotations are present, plus a few lines
-    /// surrounding the annotated spans.
+    /// When the snippet has specified annotations or
+    /// [inclusion fragments](Self::include), the renderer only shows a part of
+    /// the source code covering the lines of the specified spans, plus a few
+    /// lines surrounding these spans.
     ///
     /// **Panic**
     ///
@@ -560,8 +562,38 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
 
         self.annotations.push(Annotation {
             span,
-            priority,
+            priority: Some(priority),
             message: PrintString::from_cow(message),
+        });
+
+        self
+    }
+
+    /// Adds source code [span](ToSpan) that needs to be shown to the end user.
+    ///
+    /// Inclusion fragments are similar to [annotations](Self::annotate), except
+    /// that they don't receive special visual decorations in the final output,
+    /// and they don't have attached messages.
+    ///
+    /// When the snippet has specified inclusion fragments or
+    /// annotations, the renderer only shows a part of the
+    /// source code covering the lines of the specified spans, plus a few lines
+    /// surrounding these spans.
+    ///
+    /// **Panic**
+    ///
+    /// Panics if the message has `\n` characters.
+    pub fn include(&mut self, span: impl ToSpan) -> &mut Self {
+        let span = match span.to_site_span(self.code) {
+            Some(span) => span,
+
+            None => panic!("Invalid annotation span."),
+        };
+
+        self.annotations.push(Annotation {
+            span,
+            priority: None,
+            message: PrintString::empty(),
         });
 
         self
@@ -886,7 +918,10 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
 
         let mut scanner = Scanner::new(self);
 
-        let dim = !self.annotations.is_empty();
+        let dim = self
+            .annotations
+            .iter()
+            .any(|annotation| annotation.priority.is_some());
 
         let code_style = self.config.code_style(dim);
         let mut token_style = None;
@@ -920,25 +955,30 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
                     }
 
                     if !annotation.message.is_empty() {
-                        scanner
-                            .pending
-                            .messages
-                            .push(annotation.message(self.config, scanner.pending.code.length));
+                        if let Some(message) =
+                            annotation.message(self.config, scanner.pending.code.length)
+                        {
+                            scanner.pending.messages.push(message);
+                        }
                     }
 
                     match annotation.span.end == site {
                         true => {
-                            scanner.pending.code.style =
-                                self.config.annotation_style(annotation.priority);
-                            scanner.pending.code.write_placeholder(self.config);
+                            if let Some(priority) = annotation.priority {
+                                scanner.pending.code.style = self.config.annotation_style(priority);
+                                scanner.pending.code.write_placeholder(self.config);
+                            }
+
                             scanner.pending.annotated = true;
                         }
 
                         false => {
                             if ch == '\n' {
-                                scanner.pending.code.style =
-                                    self.config.annotation_style(annotation.priority);
-                                scanner.pending.code.write_placeholder(self.config);
+                                if let Some(priority) = annotation.priority {
+                                    scanner.pending.code.style =
+                                        self.config.annotation_style(priority);
+                                    scanner.pending.code.write_placeholder(self.config);
+                                }
                             }
 
                             scanner.stack.push(index);
@@ -959,7 +999,10 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
 
                         scanner.pending.annotated = true;
 
-                        self.config.annotation_style(priority)
+                        match priority {
+                            None => token_style.unwrap_or(code_style),
+                            Some(priority) => self.config.annotation_style(priority),
+                        }
                     }
                 };
 
@@ -995,15 +1038,18 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
             }
 
             if !annotation.message.is_empty() {
-                scanner
-                    .pending
-                    .messages
-                    .push(annotation.message(self.config, scanner.pending.code.length));
+                if let Some(message) = annotation.message(self.config, scanner.pending.code.length)
+                {
+                    scanner.pending.messages.push(message);
+                }
             }
 
             scanner.pending.annotated = true;
-            scanner.pending.code.style = self.config.annotation_style(annotation.priority);
-            scanner.pending.code.write_placeholder(self.config);
+
+            if let Some(priority) = annotation.priority {
+                scanner.pending.code.style = self.config.annotation_style(priority);
+                scanner.pending.code.write_placeholder(self.config);
+            }
 
             scanner.empty = false;
         }
@@ -1261,18 +1307,18 @@ impl ScanLine {
 
 struct Annotation<'a> {
     span: SiteSpan,
-    priority: AnnotationPriority,
+    priority: Option<AnnotationPriority>,
     message: PrintString<'a>,
 }
 
 impl<'a> Annotation<'a> {
     #[inline(always)]
-    fn message(&self, config: &SnippetConfig, offset: Column) -> Message {
-        Message {
+    fn message(&self, config: &SnippetConfig, offset: Column) -> Option<Message> {
+        Some(Message {
             offset,
-            priority: self.priority,
+            priority: self.priority?,
             string: StyleString::from_str(config, self.message.as_str()),
-        }
+        })
     }
 }
 

--- a/work/crates/main/src/format/snippet.rs
+++ b/work/crates/main/src/format/snippet.rs
@@ -120,6 +120,14 @@ pub struct SnippetConfig {
     ///
     /// Default: 80.
     pub width: usize,
+
+    /// Shows extra bottom blank line with etcetera `...` line number if the
+    /// rendrer cuts the tail of the source code listing.
+    ///
+    /// This flag is ignored when the `show_numbers` set to false.
+    ///
+    /// Default: false.
+    pub etc: bool,
 }
 
 impl Default for SnippetConfig {
@@ -143,6 +151,7 @@ impl SnippetConfig {
             summary: true,
             surround: 2,
             width: 80,
+            etc: false,
         }
     }
 
@@ -162,6 +171,7 @@ impl SnippetConfig {
             summary: false,
             surround: 2,
             width: 80,
+            etc: false,
         }
     }
 
@@ -785,6 +795,17 @@ impl<'a, 'f, C: SourceCode> Snippet<'a, 'f, C> {
                     code_length,
                     line.code,
                 )
+                .end(&mut is_first, self.formatter)?;
+        }
+
+        if self.config.etc
+            && self.config.show_numbers
+            && cover.start.line != cover.end.line
+            && cover.end.line < self.code.lines().lines_count()
+        {
+            StyleString::start(is_first)
+                .with_header_etc(self.config, numbers_length)
+                .with_code_blank(self.config, dim, has_caption, has_summary, code_length)
                 .end(&mut is_first, self.formatter)?;
         }
 

--- a/work/crates/main/src/format/snippet.rs
+++ b/work/crates/main/src/format/snippet.rs
@@ -228,7 +228,7 @@ impl SnippetConfig {
 
     #[inline(always)]
     fn box_top_left(&self) -> &'static PrintString<'static> {
-        static ASCII: PrintString<'static> = PrintString::borrowed(" ");
+        static ASCII: PrintString<'static> = PrintString::borrowed("|");
         static NON_ASCII: PrintString<'static> = PrintString::borrowed("╭");
 
         match self.ascii_drawing {
@@ -239,7 +239,7 @@ impl SnippetConfig {
 
     #[inline(always)]
     fn box_top_right(&self) -> &'static PrintString<'static> {
-        static ASCII: PrintString<'static> = PrintString::borrowed("");
+        static ASCII: PrintString<'static> = PrintString::borrowed("|");
         static NON_ASCII: PrintString<'static> = PrintString::borrowed("╮");
 
         match self.ascii_drawing {
@@ -250,7 +250,7 @@ impl SnippetConfig {
 
     #[inline(always)]
     fn box_bottom_left(&self) -> &'static PrintString<'static> {
-        static ASCII: PrintString<'static> = PrintString::borrowed(" ");
+        static ASCII: PrintString<'static> = PrintString::borrowed("|");
         static NON_ASCII: PrintString<'static> = PrintString::borrowed("╰");
 
         match self.ascii_drawing {
@@ -261,7 +261,7 @@ impl SnippetConfig {
 
     #[inline(always)]
     fn box_bottom_right(&self) -> &'static PrintString<'static> {
-        static ASCII: PrintString<'static> = PrintString::borrowed("");
+        static ASCII: PrintString<'static> = PrintString::borrowed("|");
         static NON_ASCII: PrintString<'static> = PrintString::borrowed("╯");
 
         match self.ascii_drawing {

--- a/work/crates/main/src/format/snippet.rs
+++ b/work/crates/main/src/format/snippet.rs
@@ -102,7 +102,7 @@ pub struct SnippetConfig {
     /// Default: true.
     pub caption: bool,
 
-    /// Allows summery (footer) rendering.
+    /// Allows summary (footer) rendering.
     ///
     /// Default: true.
     pub summary: bool,

--- a/work/crates/main/src/lexis/lines.rs
+++ b/work/crates/main/src/lexis/lines.rs
@@ -140,7 +140,7 @@ impl LineIndex {
 
     /// Returns the end [site](Site) of the `line`.
     ///
-    /// The end sites points to the first character of the next line or points
+    /// The end site points to the first character of the next line or points
     /// to the end of the text content.
     ///
     /// See [Line] specification for details.


### PR DESCRIPTION
 - Fixes a bug when the Snippet with annotations renders extra blank line.
 - Ascii rendering look and feel slightly improved (added missing corner elements).
 - New function `Snippet::include` allows adding "annotations" without messages and visual effects. This feature is useful when the Snippet has normal annotations, but the API user wants to show extra parts of the source code to the end user. Or if the user wants to cut just a few lines from the large code listing.
 - New configuration features:
   - `SnippetConfig::surround` allows configuring the minimal number of lines surrounding the lines with annotations and inclusion fragments. Default is 2 lines.
   - `SnippetConfig::width` sets the minimal outer width of the rendered content. Default is 80 characters.
   - `Snippet::etc` adds extra blank line with etcetera ("...") line number when the content tail is cut. Disabled by default.